### PR TITLE
Fix broken package docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Usage
 
 See here for full package docs
 
-* http://go.pkgdoc.org/github.com/ncw/gmp
+* http://godoc.org/github.com/ncw/gmp
 
 To use as in a drop in replacement for math/big, replace
 


### PR DESCRIPTION
The old link (https://www.pkgdoc.org) was pointing to some scam gold investment website. I've updated it to point to godoc.org to match the other working links, instead.